### PR TITLE
fix: overflow of post-nav-toc

### DIFF
--- a/lib/components/PostNavCard.vue
+++ b/lib/components/PostNavCard.vue
@@ -116,9 +116,7 @@ export default {
       margin 0.5rem 0
       padding-left 2rem
       max-height calc(100vh - 16rem)
-      overflow-y scroll
-      overflow -moz-scrollbars-none
-      -ms-overflow-style none
+      overflow hidden
       &::-webkit-scrollbar
         width 0 !important
       ul


### PR DESCRIPTION
Scrollbar is displayed because the value of `overflow-y` is `scroll`.

<details>
<summary>show image</summary>
<img src="https://user-images.githubusercontent.com/32789856/61940803-2bd64880-afd1-11e9-9568-4406077af366.png">
</details>


https://github.com/meteorlxy/vuepress-theme-meteorlxy/blob/c0f7bea47f65ba2f9e72b28cfa2bf66a4e5a167a/lib/components/PostNavCard.vue#L119-L121

Also, `overflow` is available for most browsers.
So I think that it is not a problem to put them together.
(ref: [Can I use - css-overflow](https://caniuse.com/#feat=css-overflow))

## Reference
MDN: [overflow](https://developer.mozilla.org/ja/docs/Web/CSS/overflow), [overflow-y](https://developer.mozilla.org/ja/docs/Web/CSS/overflow-y), [-ms-overflow-style](https://developer.mozilla.org/ja/docs/Web/CSS/-ms-overflow-style)